### PR TITLE
Fix catastrophic regex backtracking in toMark HTML escape regex

### DIFF
--- a/libs/to-mark/src/renderer.js
+++ b/libs/to-mark/src/renderer.js
@@ -112,7 +112,7 @@ export default class Renderer {
     codeblockTildes: /^(~{3,})/
   };
 
-  static markdownTextToEscapeHtmlRx = /<([a-zA-Z_][a-zA-Z0-9\-._]*)(\s|[^\\/>])*\/?>|<(\/)([a-zA-Z_][a-zA-Z0-9\-._]*)\s*\/?>|<!--[^-]+-->|<([a-zA-Z_][a-zA-Z0-9\-.:/]*)>/;
+  static markdownTextToEscapeHtmlRx = /<([a-zA-Z_][a-zA-Z0-9\-._]*)[^\\/>]*\/?>|<(\/)([a-zA-Z_][a-zA-Z0-9\-._]*)\s*\/?>|<!--[^-]+-->|<([a-zA-Z_][a-zA-Z0-9\-.:/]*)>/;
 
   static markdownTextToEscapeBackSlashRx = /\\[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~\\]/;
 


### PR DESCRIPTION
## Summary

- Replaces `(\s|[^\\/>])*` with `[^\\/>]*` in `markdownTextToEscapeHtmlRx` (libs/to-mark/src/renderer.js)
- Eliminates catastrophic backtracking that freezes the browser when users type `<` followed by non-space characters without a closing `>` (e.g. `<K` followed by text)
- The replacement is mathematically equivalent — `\s` is a strict subset of `[^\\/>]`, so the match set is identical; only the engine path changes

## Context

- ATT-6587
- The regex `(\s|[^\\/>])*` has redundant alternation: every whitespace char matches both `\s` and `[^\\/>]`, causing the engine to try 2^n combinations when no closing `>` is found
- Single occurrence in the codebase; no consumers index capture groups on this regex